### PR TITLE
com.fonts.material-icons 1.0.1

### DIFF
--- a/Fonts.Material-Icons/Packages/com.fonts.material-icons/Editor/CheckDependencies.cs
+++ b/Fonts.Material-Icons/Packages/com.fonts.material-icons/Editor/CheckDependencies.cs
@@ -142,7 +142,11 @@ namespace Fonts
                 if (string.IsNullOrWhiteSpace(tmpFontPath))
                 {
                     Selection.activeObject = font;
+                    #if UNITY_2023_1_OR_NEWER
+                    TMP_FontAsset.CreateFontAsset(font);
+                    #else
                     TMP_FontAsset_CreationMenu.CreateFontAsset();
+                    #endif
                     AssetDatabase.Refresh(ImportAssetOptions.Default);
                     var folderPath = Path.GetDirectoryName(fontPath);
                     var assetName = Path.GetFileNameWithoutExtension(fontPath);

--- a/Fonts.Material-Icons/Packages/com.fonts.material-icons/package.json
+++ b/Fonts.Material-Icons/Packages/com.fonts.material-icons/package.json
@@ -3,7 +3,7 @@
   "displayName": "Material-Icons Font",
   "description": "Material design icons is the official icon set from Google. They can be browsed at https://fonts.google.com/icons.",
   "keywords": [],
-  "version": "1.0.0",
+  "version": "1.0.1",
   "unity": "2019.4",
   "license": "Apache 2.0",
   "repository": {


### PR DESCRIPTION
Changed the `CreateFontAsset` call to use the new Text Mesh Pro API for Unity versions from 2023 and newer.
Used makros to maintain backwards compatibility.
Tested in Unity 2019.4.28f1, 2023.2.20f1 and 6000.0.25f1

Thanks for this useful package!
Would be great if you could merge the pull request and release a new version on NPM so it can still be used beyond Unity 2023.

Fixes #3